### PR TITLE
Removing error control operator

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -264,7 +264,7 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
             $options = array_merge($options, $this->_params['stream_context_options']);
         }
         $streamContext = stream_context_create($options);
-        $this->_stream = @stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $streamContext);
+        $this->_stream = stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $streamContext);
         if (false === $this->_stream) {
             throw new Swift_TransportException(
                 'Connection could not be established with host '.$this->_params['host'].


### PR DESCRIPTION
added @(error control operator) character stream_socket_client, makes impossible to debug and see the error at the stage when swiftmailer is sending a message

Error sample
```Warning: stream_socket_client(): unable to connect to smtp.mandrillapp.com:25 (Operation timed out)```